### PR TITLE
Attach to the dnf plugin logger 

### DIFF
--- a/ovl.py
+++ b/ovl.py
@@ -41,7 +41,8 @@ class OVLPlugin(dnf.Plugin):
         if not should_touch():
             return
 
-        logging.info('OverlayFS detected')
+        logger = logging.getLogger('dnf.plugin')
+        logger.info('OverlayFS detected')
         rpmdb_path = base.conf.installroot + 'var/lib/rpm/'
         try:
             for root, _, files in walk(rpmdb_path):
@@ -50,4 +51,4 @@ class OVLPlugin(dnf.Plugin):
                     with open(p, 'a'):
                         utime(p, None)
         except Exception as e:
-            logging.error("Error while doing RPMdb copy-up:\n%s", e)
+            logger.error("Error while doing RPMdb copy-up:\n%s", e)


### PR DESCRIPTION
In its current state this plugin appears to put dnf into a verbose mode where a significant amount of debugging is turned on. This PR adjust the code to attach to the dnf plugin logger as outlined here: https://dnf.readthedocs.io/en/latest/api_common.html

Before:
```
Step 3/4 : RUN dnf -y install vim
 ---> Running in ef9377d2f9f4
DEBUG:dnf:DNF version: 4.2.18
DDEBUG:dnf:Command: dnf -y install vim 
DDEBUG:dnf:Installroot: /
DDEBUG:dnf:Releasever: 31
DEBUG:dnf:cachedir: /var/cache/dnf
DDEBUG:dnf:Base command: install
DDEBUG:dnf:Extra commands: ['-y', 'install', 'vim']
```
After:
```
Step 3/5 : RUN dnf -y update
 ---> Running in 00ebef35ae69
OverlayFS detected
Fedora Modular 31 - x86_64                      2.0 MB/s | 5.2 MB     00:02    
Fedora Modular 31 - x86_64 - Updates            5.3 MB/s | 4.0 MB     00:00    
Fedora 31 - x86_64 - Updates                    5.3 MB/s |  21 MB     00:03    
Fedora 31 - x86_64                               21 MB/s |  71 MB     00:03    
```
