### PR TITLE
Fix RHEL/CentOS/UBI 8 not being recognized

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,41 @@
 # dnf-plugin-ovl
-workaround to run dnf on overlayfs. A port of yum-plugin-ovl to dnf.
+Workaround to run `dnf` on overlayfs. A port of `yum-plugin-ovl` to `dnf`.
 
 ## When you need it
-Running dnf (or yum or rpm) within inside overlayfs (for example inside docker) will result in errors similar to 
+Running `dnf` (or `yum` or `rpm`) with the RPM database on an overlayfs mount (_e.g._ in a container) will result in errors similar to
 ```
 rpmdb: BDB0060 PANIC: fatal region error detected; run recovery
 ```
-as soon as you run dnf on different layers.
+or
+```
+error: rpmdbNextIterator: skipping h# 173 blob size(4836): BAD, 8 + 16 * il(70) + dl(3708)
+```
+as soon as you run `dnf` on different layers when building an image.
 
 ## Install
-
-It is included in Fedora's repository:
+It is included in Fedora's repository and EPEL:
 ```
 dnf install -y dnf-plugin-ovl
 ```
 
-## Background
+## Verifying installation
+```
+dnf updateinfo -v
+```
+Should show (second line only if an overlayfs system detected):
+```
+Loaded plugins: ..., ovl, ...
+OverlayFS detected
+```
 
-Opening a file on OverlayFS in read-only mode causes the file from
-lower layer to be opened, then later on, if the same file is opened
-in write mode, a copy-up into the upper    layer    takes    place,
-resulting into a new file being opened.
-Since dnf opens the RPMdb first read-only, and then
-also with write access, we need to copy-up the files beforehand to
-make sure that the access is consistent.
+## Background
+Opening a file on an OverlayFS in read-only mode causes the file from lower layer to be opened, then later on, if the same file is re-opened in write mode, a copy-up into the upper layer takes place, resulting into a new file being opened.
+
+Since `dnf` opens the RPMdb first read-only, and then also with write access, we need to copy-up the files beforehand to make sure that the access is consistent.
 
 ## Building
-
 ```
+rpmbuild --nobuild --nodeps dnf-plugin-ovl.spec  # Will fail, but creates missing dirs on new machine
 spectool -g -R dnf-plugin-ovl.spec
-rpmbuild --target noarch --clean -v -bb dnf-plugin-ovl.spec 
+rpmbuild --clean -v -bb dnf-plugin-ovl.spec
 ```

--- a/dnf-plugin-ovl.spec
+++ b/dnf-plugin-ovl.spec
@@ -1,7 +1,7 @@
 Name:    dnf-plugin-ovl
-Version: 0.0.3
-Release: 2%{?dist}
-Summary: GNU Hello
+Version: 0.0.4
+Release: 1%{?dist}
+Summary: Workaround to run dnf on overlayfs
 URL:     https://github.com/FlorianLudwig/dnf-plugin-ovl
 License: GPLv2+
 
@@ -20,16 +20,17 @@ Workaround to run dnf on overlayfs. A port of yum-plugin-ovl to dnf.
 
 %build
 
-
 %install
-install -D -p ovl.py %{buildroot}/%{python3_sitelib}/dnf-plugins/ovl.py
+install -D -m 644 -p ovl.py %{buildroot}/%{python3_sitelib}/dnf-plugins/ovl.py
 
 %files
 %{python3_sitelib}/dnf-plugins/ovl.py
-%{python3_sitelib}/dnf-plugins/__pycache__/ovl.*
-%{python3_sitelib}/dnf-plugins/__pycache__/ovl.*
+%{python3_sitelib}/dnf-plugins/__pycache__/ovl.*.pyc
 
 %changelog
+* Thu May 07 2020 Aaron D. Marasco <dnf-plugin-ovl@marascos.net> - 0.0.4-1
+- Fix overlayfs detection on CentOS 8 / RHEL 8 / Red Hat's UBI images
+
 * Mon Nov 05 2018 Till Hofmann <thofmann@fedoraproject.org> - 0.0.1-2
 - Add missing Requires and BuildRequires
 - Make package noarch

--- a/ovl.py
+++ b/ovl.py
@@ -26,14 +26,16 @@ def should_touch():
     Touch the files only once we've verified that
     we're on overlay mount
     """
-    with open('/etc/mtab') as f:
-        line = f.readline()
-        return line and line.startswith('overlay /')
+    with open('/etc/mtab') as mtab:
+        for line in mtab:
+            if line.split()[1] == '/':  # Check rootfs only
+                return 'overlay' in line  # Some images say "overlay" and others "overlayfs"
     return False
 
 
 class OVLPlugin(dnf.Plugin):
     """workaround OverlayFS non compliance with posix"""
+    name = "ovl"
 
     def __init__(self, base, cli):
         super(OVLPlugin, self).__init__(base, cli)


### PR DESCRIPTION
Also includes a fix for plugin name being '<invalid>' with "dnf -v"

Replaces #5 - apparently you cannot change source branch. This squashes and puts a nicer label on it.